### PR TITLE
Inject NavHostController to all children of main activity

### DIFF
--- a/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/MainActivity.kt
+++ b/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/MainActivity.kt
@@ -21,7 +21,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            VehicleDiaryNavHost()
+            val navController = rememberNavController()
+            VehicleDiaryNavHost(navController = navController)
         }
     }
 }

--- a/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/presentation/event/EventListView.kt
+++ b/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/presentation/event/EventListView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.cool.element.vehiclediary.domain.VEvent
 import com.cool.element.vehiclediary.presentation.Screen
 import com.cool.element.vehiclediary.presentation.navigation.AppBarView

--- a/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/presentation/navigation/VehicleDiaryNavHost.kt
+++ b/android/VehicleDiary/app/src/main/java/com/cool/element/vehiclediary/presentation/navigation/VehicleDiaryNavHost.kt
@@ -11,21 +11,21 @@ import com.cool.element.vehiclediary.domain.Vehicle
 import com.cool.element.vehiclediary.domain.VEvent
 
 @Composable
-fun VehicleDiaryNavHost(navHostController: NavHostController) {
+fun VehicleDiaryNavHost(navController: NavHostController) {
     NavHost(
-        navController = navHostController,
+        navController = navController,
         startDestination = Screen.VehiclesListScreen.route
     ) {
         composable(Screen.VehiclesListScreen.route) {
             VehicleListView(
                 vehicles = Vehicle.sampleList,
-                navController = navHostController
+                navController = navController
             )
         }
         composable(Screen.EventsListScreen.route) {
             EventListView(
                 events = VEvent.sampleList,
-                navController = navHostController
+                navController = navController
             )
         }
     }


### PR DESCRIPTION
- inject NavHostController to all children of main activity
- persist NavHostController instance if it is need by Android best practices

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cool-element-com/vehicle-diary/pull/24?shareId=d0499096-5f53-402b-82cc-a761f53d83f7).